### PR TITLE
Support python3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 ## 0.2.0 (unreleased)
 
   - Upgraded to argparse since optparse is deprecated.
+  - Support python3
 
 ## 0.1.2-dev
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -157,7 +157,7 @@ Custom Command-line Options and Arguments
 Often checks can require additional command line options. Since **PyNagios**
 plugins parse the command line on their own, you should define additional
 options on the plugin itself, rather than attempting to use your own command
-line parser. **PyNagios** uses Python's built-in ``optparse`` library.
+line parser. **PyNagios** uses Python's built-in ``argparse`` library.
 
 We'll extend our example to add an option to multiply the value by the
 given option value:::

--- a/pynagios/__init__.py
+++ b/pynagios/__init__.py
@@ -6,10 +6,10 @@ throughout the library.
 
 import argparse
 
-from plugin import Plugin, OK, WARNING, CRITICAL, UNKNOWN
-from range import Range
-from response import Response
-from status import Status
+from pynagios.plugin import Plugin, OK, WARNING, CRITICAL, UNKNOWN
+from pynagios.range import Range
+from pynagios.response import Response
+from pynagios.status import Status
 
 version = '0.1.2-dev'
 """Current version of PyNagios"""

--- a/pynagios/perf_data.py
+++ b/pynagios/perf_data.py
@@ -6,7 +6,8 @@ called instead of having to create an entire :py:class:`PerfData` object.
 """
 
 import re
-from range import Range
+from pynagios.range import Range
+
 
 class PerfData(object):
     """
@@ -190,4 +191,3 @@ class PerfData(object):
             return "'%s'" % value.replace("'", "''")
         else:
             return value
-

--- a/pynagios/range.py
+++ b/pynagios/range.py
@@ -3,6 +3,7 @@ Contains a class to represent a range that adheres to the range
 format defined by Nagios.
 """
 
+
 class RangeValueError(ValueError):
     """
     This exception is raised when an invalid value is passed to
@@ -10,6 +11,7 @@ class RangeValueError(ValueError):
     human readable explanation of the error.
     """
     pass
+
 
 class Range(object):
     """

--- a/pynagios/response.py
+++ b/pynagios/response.py
@@ -4,8 +4,9 @@ encapsulates the response format that Nagios expects.
 """
 
 import sys
-from perf_data import PerfData
+from pynagios.perf_data import PerfData
 from collections import OrderedDict as odic
+
 
 class Response(object):
     """
@@ -55,7 +56,7 @@ class Response(object):
         This prints out the response to ``stdout`` and exits with the
         proper exit code.
         """
-        print(str(self))
+        print(str(self).encode('UTF-8'))
         sys.exit(self.status.exit_code)
 
     def __str__(self):
@@ -73,14 +74,15 @@ class Response(object):
 
           OK: 27 users logged in|users=27;0:40;0:60;0;
         """
-        result = "%s:" % self.status.name
+
+        result = u"%s:" % self.status.name
 
         if self.message is not None:
             result += " %s" % self.message
 
         if len(self.perf_data) > 0:
             # Attach the performance data to the result
-            data = [str(val) for key,val in self.perf_data.iteritems()]
+            data = [str(val) for key, val in self.perf_data.items()]
             result += '|%s' % (' '.join(data))
 
         return result

--- a/pynagios/status.py
+++ b/pynagios/status.py
@@ -1,6 +1,6 @@
 """
 This module provides the Status class, which encapsulates
-a status code for Nagios.
+a status code for a Plugin.
 """
 
 class Status(object):
@@ -17,11 +17,25 @@ class Status(object):
         **Note**: In general, this should never be called since the standard
         statuses are exported from ``pynagios``.
         """
+
+        assert isinstance(exit_code, int)
+        assert isinstance(name, str)
+
         self.name = name
         self.exit_code = exit_code
 
     def __repr__(self):
         return "Status(name=%s, exit_code=%d)" % (repr(self.name), self.exit_code)
 
-    def __cmp__(self, other):
-        return cmp(self.exit_code,other.exit_code)
+    def __lt__(self, other):
+        return (self.exit_code < other.exit_code)
+
+    def __eq__(self, other):
+        return (self.exit_code == other.exit_code)
+
+    def __ne__(self, other):
+        return (self.exit_code != other.exit_code)
+
+    def __gt__(self, other):
+        return (self.exit_code > other.exit_code)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 pytest==2.1.0
 sphinx
+tox
+six

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -6,7 +6,6 @@ from argparse import ArgumentError, ArgumentParser
 import sys
 import pytest
 import pynagios
-from optparse import OptionConflictError
 from pynagios import Plugin, Range, Response
 
 class TestPlugin(object):

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -2,13 +2,14 @@
 Contains tests for the pynagios.Response class.
 """
 
-import cStringIO
+from io import StringIO
+from io import BytesIO
 import sys
 import pynagios
 from pynagios import Response
 
-class TestResponse(object):
 
+class TestResponse(object):
     def test_status_gets_set_by_initializer(self):
         "Tests that the status can be set by the constructor."
         instance = Response(pynagios.OK)
@@ -50,15 +51,18 @@ class TestResponse(object):
 
     def test_exit(self, monkeypatch):
         """
-        Tests that responses exit with the proper exit code and
-        stdout output.
+        Tests that responses exit with the proper exit code and stdout output.
         """
+
         def mock_exit(code):
             mock_exit.exit_status = code
 
         mock_exit.exit_status = None
 
-        output = cStringIO.StringIO()
+        if sys.version_info[0] == 3:
+            output = StringIO()
+        else:
+            output = BytesIO()
         monkeypatch.setattr(sys, 'stdout', output)
         monkeypatch.setattr(sys, 'exit', mock_exit)
 
@@ -66,4 +70,4 @@ class TestResponse(object):
         instance.exit()
 
         assert pynagios.OK.exit_code == mock_exit.exit_status
-        assert "%s\n" % str(instance) == output.getvalue()
+        assert "%s\n" % str(instance).encode() == output.getvalue()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py34,py27
+[testenv]
+deps=
+  pytest
+  six
+commands=
+  py.test


### PR DESCRIPTION
This work makes the necessary updates to the code to support both
Python2 and Python3.  To support this effort, updates to testing using
tox was implemented as an easy way to test compatibility in both
version.  This work is relatively clean, though in the test_result case,
I couldn't end up working out the correct incantation of .encode(),
BytesIO and StringIO to make each test pass, so its a hardcoded switch
to get the tests to pass.  I don't expect this to adversely effect the
usefulness of this code.